### PR TITLE
Always track cars

### DIFF
--- a/app/controllers/nitrogen.js
+++ b/app/controllers/nitrogen.js
@@ -6,28 +6,6 @@ export default Ember.Controller.extend({
     subscribeToNitrogen: false,
 
     actions: {
-        createNewDevice: function (options) {
-            var appController = this.get('appController'),
-                nitrogenService = appController.get('nitrogenService'),
-                currentUsers = appController.get('currentUser'),
-                apikey = currentUsers.content.get('api_key'),
-                newDevice;
-
-            if (apikey) {
-                options = _.defaults(options, {
-                    nickname: 'OxideDevice',
-                    name: 'Oxide Device',
-                    tags: ['oxide'],
-                    api_key: apikey
-                });
-
-                newDevice = new nitrogen.Device(options);
-                nitrogenService.connect(newDevice, function (err, session, principal) {
-                    console.log(session, principal);
-                });
-            }
-        },
-
         subscribeToNitrogen: function (originalController, callback) {
             var appController = this.get('appController'),
                 nitrogenSession = appController.get('nitrogenSession');
@@ -36,11 +14,7 @@ export default Ember.Controller.extend({
                 return;
             }
 
-            nitrogenSession.onMessage({
-                $or: [
-                    { type: 'location' }
-                ]
-            }, function (message) {
+            nitrogenSession.onMessage({ type: 'location' }, message => {
                 originalController.send(callback, message);
             });
 

--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -41,5 +41,9 @@
                 vertical-align: middle;
             }
         }
+
+        a {
+            text-transform: none;
+        }
     }
 }

--- a/app/templates/-car-card.hbs
+++ b/app/templates/-car-card.hbs
@@ -1,9 +1,10 @@
-<li class="collection-item avatar" {{action 'toggleCar' car}}>
-    <i {{bind-attr class="car.trackOnMap:green:grey :mdi-maps-my-location :circle"}}></i>
+<li class="collection-item avatar">
+    <i {{action 'toggleCar' car}} {{bind-attr class="car.trackOnMap:green:grey :mdi-maps-my-location :circle"}}></i>
     <span class="title">{{car.name}}</span>
     <p>
         {{#if car.gps.firstObject.timestamp}}
-            Seen: {{pretty-Date car.gps.firstObject.timestamp}}
+            <p>Seen: {{pretty-Date car.gps.firstObject.timestamp}}</p>
+            <a {{action 'centerOnCar' car}}>Go to last known location</a>
         {{else}}
             Never seen
         {{/if}}


### PR DESCRIPTION
Closes #37

- On dashboard `init`, all cars are marked as ‘tracked’. They can still
be deselected, though.
- Smaller fixes to messaging handling & dashboard controller