### PR TITLE
Don't reauthenticate when the session is still good

### DIFF
--- a/app/authenticators/nitrogen.js
+++ b/app/authenticators/nitrogen.js
@@ -35,9 +35,9 @@ export default Base.extend({
             // Let's take a look at our session here - if it looks like it's still good,
             // we can return right away
             if (session && session.principal && session.accessToken && _nitrogenService) {
-                return resolve({ 
-                    user: session.principal, 
-                    accessToken: session.accessToken 
+                return resolve({
+                    user: session.principal,
+                    accessToken: session.accessToken
                 });
             }
 
@@ -52,8 +52,8 @@ export default Base.extend({
             nitrogenService.resume(principal, function (err, session, principal) {
                 var store;
 
-                if (err) { 
-                    return reject(err); 
+                if (err) {
+                    return reject(err);
                 }
 
                 store = self.container.lookup('store:main');

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -3,5 +3,5 @@ import Config from '../config/environment';
 
 export default Ember.Controller.extend({
     version: Config.APP.version,
-    fullConfig: Config.APP,
+    fullConfig: Config.APP
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -2,17 +2,6 @@ import Ember from 'ember';
 import Config from '../config/environment';
 
 export default Ember.Controller.extend({
-
     version: Config.APP.version,
-
     fullConfig: Config.APP,
-
-    devices: function () {
-        return this.store.find('device');
-    }.property(),
-
-    currentUser: function () {
-        return this.store.find('user', 'me');
-    }.property()
-
 });

--- a/app/controllers/nitrogen.js
+++ b/app/controllers/nitrogen.js
@@ -27,11 +27,16 @@ export default Ember.Controller.extend({
                 limit = (messageLimit) ? messageLimit : 0;
 
             if (nitrogenSession && principalId) {
-                nitrogen.Message.find(nitrogenSession, { type: 'location', from: principalId }, { sort: { ts: -1 }, limit: limit },
-                    function (err, locations) {
-                        if (err) {
-                            return;
-                        }
+                nitrogen.Message.find(nitrogenSession, {
+                    type: 'location', from: principalId
+                },
+                {
+                    sort: { ts: -1 },
+                    limit: limit
+                }, function (err, locations) {
+                    if (err) {
+                        return;
+                    }
                         originalController.send(callback, locations, principalId);
                     }
                 );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8311,9 +8311,9 @@
       }
     },
     "ember-cli-simple-auth": {
-      "version": "0.8.0-beta.1",
-      "from": "ember-cli-simple-auth@0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-simple-auth/-/ember-cli-simple-auth-0.8.0-beta.1.tgz"
+      "version": "0.8.0-beta.2",
+      "from": "ember-cli-simple-auth@0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-simple-auth/-/ember-cli-simple-auth-0.8.0-beta.2.tgz"
     },
     "ember-cli-uglify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-moment": "0.0.2",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-sass": "3.3.0",
-    "ember-cli-simple-auth": "0.8.0-beta.1",
+    "ember-cli-simple-auth": "^0.8.0-beta.2",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "1.0.2",


### PR DESCRIPTION
Closes #70

In our nitrogen authenticator, we used to always reauthenticate
whenever Simple Auth had any doubts about the validity of the session.
If two tabs were open, this resulted in a reauthentication loop.

This change makes sure that we check the session and only
reauthenticate if we actually need to.