### PR TITLE
Mobile responsive layout (tablets) and fixes #26 Collapsing cards

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -225,8 +225,20 @@ export default Ember.ArrayController.extend({
         },
 
         selectCar: function (device) {
+            var $container = Ember.$('.carlist');
+
+            $container.addClass('expanded');
+
             this.set('selectedCar', device);
             this.send('centerOnCar', device);
+        },
+
+        deselectCar: function () {
+            var $container = Ember.$('.carlist');
+
+            $container.removeClass('expanded');
+
+            this.set('selectedCar', null);
         }
     }
 });

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -14,6 +14,21 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             // If the menu isn't out, pull it out
             $container.toggleClass('expanded');
             $menu.toggleClass('expanded');
+        },
+
+        toggleVehicleList: function () {
+            var $container = Ember.$('.vehicle-list'),
+                $icon = Ember.$('.vehicle-list > .card-content > .card-title > i');
+
+            $container.toggleClass('collapsed');
+            if ($icon.hasClass('mdi-navigation-expand-less')) {
+                $icon.removeClass('mdi-navigation-expand-less');
+                $icon.addClass('mdi-navigation-expand-more');
+            } else {
+                $icon.removeClass('mdi-navigation-expand-more');
+                $icon.addClass('mdi-navigation-expand-less');
+            }
+
         }
     }
 });

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -9,15 +9,11 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     actions: {
         toggleSideNav: function () {
             var $container = Ember.$('.main-container'),
-                $containerMargin = $container.css('margin-left');
+                $menu = Ember.$('.menu-flyout');
 
             // If the menu isn't out, pull it out
-            if ($containerMargin !== '250px') {
-                $container.animate({'margin-left': '250px'}, { duration: 200, queue: false});
-            } else {
-                $container.animate({'margin-left': '50px'}, { duration: 200, queue: false});
-            }
-
+            $container.toggleClass('expanded');
+            $menu.toggleClass('expanded');
         }
     }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,10 @@
-@import 'color-overrides';
+//Grid unit definition
+$baseunit: 48px;
+$marginunit: $baseunit / 6;
+
+@import 'mediaqueries';
 @import 'materialize';
+@import 'color-overrides';
 @import 'type-overrides';
 @import 'open-sans';
 @import 'preview';
@@ -7,6 +12,7 @@
 @import 'menu';
 @import 'dashboard';
 @import 'login';
+
 
 body, html {
     background-color: $primary-background-color;

--- a/app/styles/color-overrides.scss
+++ b/app/styles/color-overrides.scss
@@ -10,3 +10,4 @@ $secondary-color: #2e80ab;
 $success-color: color("green", "base");
 $error-color: color("red", "base");
 $link-color: color("light-blue", "darken-1");
+$disabled-text-color: color("grey", "darken-1");

--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -153,7 +153,7 @@
         .card-content {
             margin-bottom: 0;
         }
-        
+
         .collection.carlist {
             display: none;
         }
@@ -226,12 +226,12 @@
         .card .collection.carlist,
         .card .collection.carlist.expanded  {
             min-height: 160px;
-            max-height: calc(100vh * 0.30 - 50px);
+            max-height: calc(100vh * 0.30 - 50px) !important;
         }   
 
         .card.car-selected {
             min-height: 224px;
-            max-height: calc(100vh * 0.30 - 50px);
+            max-height: calc(100vh * 0.30 - 50px) !important;
         }
     }
 

--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -1,31 +1,37 @@
-.main-container {
-    margin-left: 50px;
-}
-
 #map {
     position: relative;
+    width: 100%;
+    height: 100vh;
 }
 
 .content-overlay {
-    position: absolute;
+    position: relative;
     z-index: 1001;
-    width: 350px;
+    width: $baseunit * 7;
+}
+
+.cards::before {
+    content: "";
+    width: 100%;
+    height: $marginunit;
+    background-color: transparent;
+    display: block;
+    float:left;
 }
 
 .cards {
-    position: absolute;
+    position: relative;
     z-index: 1001;
-    width: 350px;
-    margin-left: 20px;
-    margin-top: 3px;
-
-    .vin {
-        color: #7F7F7F;
-    }
+    margin: 0 0 0 $marginunit;
     
+
+
     .card {
+        float: left;
         border-radius: 0;
         padding-top:0;
+        margin: $marginunit 0 0 $marginunit;
+        width: $baseunit * 7;
         
         .card-title {
             padding: 18px 20px 13px;
@@ -35,7 +41,7 @@
         }
 
         .card-content {
-            margin-bottom: 10px;
+            margin-bottom: $marginunit;
             max-height: calc(100vh * 0.40);
             padding: 0;
             border-radius: 0;
@@ -44,7 +50,7 @@
         .collection.carlist {
             overflow-y: auto;
             max-height: calc(100vh * 0.40 - 70px);
-            margin-bottom: -10px;
+            margin-bottom: $marginunit * -1;
             padding: 0 20px 20px 20px;
             background-color: transparent;
         }
@@ -54,7 +60,7 @@
         .collection::before {
             content: "";
             position:absolute;
-            height: 10px;
+            height: $marginunit;
             left: 0px;
             /* scrollbars are 17px wide on desktop browsers */
             width: calc(100% - 17px);
@@ -101,7 +107,7 @@
 
         .collection-item.car {
             padding-left: 0;
-            padding-top: 7px;
+            padding-top: $marginunit - 1;
             padding-bottom: 1px;
 
             h4 {
@@ -109,6 +115,10 @@
                 margin: 0;
                 line-height: 1.1em;
                 text-transform: capitalize;
+            }
+
+            .vin {
+                color: $disabled-text-color;
             }
         }
 
@@ -132,7 +142,7 @@
 
                 img {
                     float: left;
-                    margin-right: 10px;
+                    margin-right: $marginunit;
                 }
             }
 
@@ -165,5 +175,20 @@
             
         }
         
+    }
+}
+
+@include tablet-portrait {
+    #map {
+        height: calc( 100vh - $baseunit );
+    }
+    .content-overlay {
+        position: relative;
+        z-index: 1001;
+        width: inherit;
+    }
+
+    .cards {
+        width: inherit;
     }
 }

--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -34,25 +34,31 @@
         width: $baseunit * 7;
         
         .card-title {
-            padding: 18px 20px 13px;
+            padding: 18px #{$marginunit * 2} 13px;
             line-height: $font-size-title;
             font-weight: normal;
             color: color("shades", "black");
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+
+            span {
+                display: inline-block;
+                max-width: calc( 100% - #{$marginunit * 4});
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+
+            i.right {
+                margin-left: 12px;
+            }
         }
 
         .card-content {
             margin-bottom: $marginunit;
-            max-height: calc(100vh * 0.40);
+            //max-height: calc(100vh * 0.60);
             padding: 0;
             border-radius: 0;
-        }
-        
-        .collection.carlist {
-            overflow-y: auto;
-            max-height: calc(100vh * 0.40 - 70px);
-            margin-bottom: $marginunit * -1;
-            padding: 0 20px 20px 20px;
-            background-color: transparent;
         }
         
         /* Provides guaranteed padding inside scroll-overflow collections 
@@ -73,6 +79,7 @@
             background: linear-gradient(to bottom,  rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%); /* W3C */
             filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#00ffffff',GradientType=0 ); /* IE6-9 */
         }
+
         .collection::after {
             content: "";
             position:absolute;
@@ -100,9 +107,25 @@
             height: inherit;
             padding-left: 55px;
             padding-right: 0px;
-            overflow: hidden;
-            text-overflow: ellipsis;
             position: relative;
+        }
+
+        a {
+            text-transform: none;
+        }
+    }
+
+    .card.vehicle-list {
+        .collection.carlist {
+            overflow-y: auto;
+            max-height: calc(100vh * 0.70 - 50px);
+            margin-bottom: $marginunit * -1;
+            padding: 0 20px 20px 20px;
+            background-color: transparent;
+        }
+
+        .collection.carlist.expanded {
+            max-height: calc(100vh * 0.70 - 250px);
         }
 
         .collection-item.car {
@@ -111,19 +134,28 @@
             padding-bottom: 1px;
 
             h4 {
-                font-size: 1.2em;
+                font-size: $font-size-sub-headline;
                 margin: 0;
-                line-height: 1.1em;
-                text-transform: capitalize;
+                line-height: $font-size-sub-headline;
+                text-transform: capitalize;  
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
 
             .vin {
                 color: $disabled-text-color;
             }
         }
+    }
 
-        a {
-            text-transform: none;
+    .card.vehicle-list.collapsed {
+        .card-content {
+            margin-bottom: 0;
+        }
+        
+        .collection.carlist {
+            display: none;
         }
     }
 
@@ -180,7 +212,7 @@
 
 @include tablet-portrait {
     #map {
-        height: calc( 100vh - $baseunit );
+        height: calc( 100vh - #{$baseunit} );
     }
     .content-overlay {
         position: relative;
@@ -190,5 +222,28 @@
 
     .cards {
         width: inherit;
+
+        .card .collection.carlist,
+        .card .collection.carlist.expanded  {
+            min-height: 160px;
+            max-height: calc(100vh * 0.30 - 50px);
+        }   
+
+        .card.car-selected {
+            min-height: 224px;
+            max-height: calc(100vh * 0.30 - 50px);
+        }
     }
+
+    
+}
+
+@include desktop {
+     /*.cards::after {
+        content: "";
+        display: block;
+        float: left;
+        height: calc( 100vh * 0.3 );
+        width: 320px;
+    }*/
 }

--- a/app/styles/mediaqueries.scss
+++ b/app/styles/mediaqueries.scss
@@ -1,0 +1,49 @@
+
+// Definitions for media query breakpoints 
+
+// Effective resolutions, not physical pixels
+$phone-width: 480px;
+$tablet-width: 768px;
+$desktop-width: 1280px;
+
+@mixin retina {
+    @media
+        only screen and (-webkit-min-device-pixel-ratio: 2),
+        only screen and (   min--moz-device-pixel-ratio: 2),
+        only screen and (     -o-min-device-pixel-ratio: 2/1),
+        only screen and (        min-device-pixel-ratio: 2),
+        only screen and (                min-resolution: 192dpi),
+        only screen and (                min-resolution: 2dppx) {
+            @content;
+    }
+}
+
+@mixin phone-landscape {
+    @media (max-width: #{$phone-width - 1px}) and (orientation: landscape) {
+        @content;
+    }
+}
+
+@mixin phone-portrait {
+    @media (max-width: #{$phone-width - 1px}) and (orientation: portrait) {
+        @content;
+    }
+}
+
+@mixin tablet-landscape {
+    @media (min-width: #{$phone-width}) and (max-width: #{$desktop-width - 1px}) and (orientation: landscape) {
+        @content;
+    }
+}
+
+@mixin tablet-portrait {
+    @media (min-width: #{$phone-width}) and (max-width: #{$desktop-width - 1px}) and (orientation: portrait) {
+        @content;
+    }
+}
+
+@mixin desktop {
+    @media (min-width: #{$desktop-width}) and (orientation: landscape) {
+        @content;
+    }
+}

--- a/app/styles/menu.scss
+++ b/app/styles/menu.scss
@@ -8,7 +8,8 @@
     width: $baseunit;
 }
 
-.menu-nav, .menu-flyout {
+.menu-nav, 
+.menu-flyout {
     ul {
         width: $baseunit * 5;
         color: #fff;

--- a/app/styles/menu.scss
+++ b/app/styles/menu.scss
@@ -1,14 +1,20 @@
-.menu {
-    width: 50px;
-    height: 50px;
-    float: left;
+.menu-flyout {
+    display: none;
+    width: $baseunit * 5;
+    height:100%;
+}
 
+.menu-nav {
+    width: $baseunit;
+}
+
+.menu-nav, .menu-flyout {
     ul {
-        width: 250px;
+        width: $baseunit * 5;
         color: #fff;
         background-color: $primary-background-color;
         margin-top: 0;
-        height: 45px;
+        height: 100%;
         line-height: 45px;
         
         li.selected {
@@ -20,13 +26,13 @@
         
         li i {
             font-size: 30px;
-            margin-left: 10px;
+            margin-left: $marginunit;
             text-align: center;
             vertical-align: middle;
         }
 
         li span {
-            margin-left: 10px;
+            margin-left: $marginunit;
             vertical-align: middle;
         }
 
@@ -47,5 +53,104 @@
         li:hover {
             background-color: rgba(255,255,255,.10);
         }
+    }
+}
+
+@include tablet-portrait {
+    .main-container {
+        margin-top: 0px;
+    }
+
+    .menu-nav {
+        width: 100%;
+        height: $baseunit;
+
+        ul {
+            width: 100%;
+
+            li {
+                float:left;
+                display: none;
+                height: $baseunit;
+                overflow: hidden;
+            }
+
+            li:hover {
+                background-color: transparent;
+            }
+
+            li:first-child {
+                display: inline-block;
+                width: 50px;
+            }
+
+            li.selected {
+                display: inline-block;
+                background-color: transparent;
+            }
+
+            li.selected:hover {
+                background-color: transparent;
+            }
+
+            li.logout {
+                float:right;
+                display: block;
+                width: $baseunit;
+            }
+        }
+    }
+
+    .menu-flyout.expanded {
+        display: block;
+        position: absolute;
+        top:0px;
+        left:0px;
+        z-index: 1002;
+        width: 100%;
+            ul {
+                background-color: $primary-background-color;
+                height:100%;
+
+                li:first-child {
+                    height: $baseunit;
+                }
+            }
+    }
+}
+
+@include desktop {
+    .main-container {
+        margin-left: 50px;
+        -webkit-transition: .2s ease-in-out;
+        -moz-transition: .2s ease-in-out;
+        -o-transition: .2s ease-in-out;
+        transition: .2s ease-in-out;
+    }
+
+    .main-container.expanded {
+        margin-left: 250px;
+    }
+
+    .menu-nav {
+        float:left;
+    }
+}
+
+@include tablet-landscape {
+    .main-container {
+        margin-left: $baseunit;
+        -webkit-transition: .2s ease-in-out;
+        -moz-transition: .2s ease-in-out;
+        -o-transition: .2s ease-in-out;
+        transition: .2s ease-in-out;
+    }
+
+    .main-container.expanded {
+        margin-left: $baseunit * 5;
+    }
+
+    .menu-nav {
+        float:left;
     }
 }

--- a/app/templates/-car-selected-card.hbs
+++ b/app/templates/-car-selected-card.hbs
@@ -1,6 +1,9 @@
 <div class="card white car-selected">
     <div class="card-content">
-        <div class="card-title">{{selectedCar.name}}</div>
+        <div class="card-title">
+            <span>{{selectedCar.name}}</span>
+            <i class="mdi-navigation-close right" {{action "deselectCar" car}}></i>
+        </div>
         {{!-- Info --}}
         <div class="info">
             <img src="http://placehold.it/110x100" width="110" height="100" />

--- a/app/templates/-menu.hbs
+++ b/app/templates/-menu.hbs
@@ -1,16 +1,14 @@
-<div class="menu">
-    <ul>
-        <li {{action "toggleSideNav"}}>
-            <i class="mdi-navigation-menu" title="Menu"></i>
-            <span>Connected Car</span>
-        </li>
-        <li class="selected">
-            <i class="mdi-maps-layers" title="Overview"></i>
-            <span>Overview</span>
-        </li>
-        <li {{action 'invalidateSession' }}>
-            <i class="mdi-social-person" title="Sign out"></i>
-            <span>Sign out</span>
-        </li>
-    </ul>
-</div>
+<ul>
+    <li {{action "toggleSideNav"}}>
+        <i class="mdi-navigation-menu" title="Menu"></i>
+        <span>Connected Car</span>
+    </li>
+    <li class="selected">
+        <i class="mdi-maps-layers" title="Overview"></i>
+        <span>Overview</span>
+    </li>
+    <li class="logout" {{action 'invalidateSession' }}>
+        <i class="mdi-social-person" title="Sign out"></i>
+        <span>Sign out</span>
+    </li>
+</ul>

--- a/app/templates/components/ox-map.hbs
+++ b/app/templates/components/ox-map.hbs
@@ -1,1 +1,1 @@
-<div id='map' style="width:100%; height:100vh;"></div>
+<div id='map'></div>

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -1,5 +1,6 @@
-{{partial "menu"}}
-
+<div class="menu-nav">
+    {{partial "menu"}}
+</div>
 <div class="main-container">
     <div class="content-overlay">
         <div class="cards">
@@ -25,4 +26,7 @@
     {{!-- Map --}}
 
     {{ox-map mapReference=mapReference}}
+</div>
+<div class="menu-flyout" {{action "toggleSideNav"}}>
+    {{partial "menu"}}
 </div>

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -4,9 +4,12 @@
 <div class="main-container">
     <div class="content-overlay">
         <div class="cards">
-            <div class="card white">
+            <div class="card vehicle-list white">
                 <div class="card-content">
-                    <div class="card-title">Tracked Vehicles</div>
+                    <div class="card-title">
+                        <span>Tracked Vehicles</span>
+                        <i class="mdi-navigation-expand-less right" {{action "toggleVehicleList"}}></i>
+                    </div>
                     <ul class="carlist collection">
                         {{#each car in model}}
                             {{partial "car-list-item"}}


### PR DESCRIPTION
Adds initial mobile responsive layouts for tablets,
![image](https://cloud.githubusercontent.com/assets/1085397/7607498/ab697cdc-f916-11e4-96dd-1c055cc0aa9e.png)

Adds collapsing cards and collapse action for vehicle list
Adds "Close" selected car to deselect it and close the card
![image](https://cloud.githubusercontent.com/assets/1085397/7607431/1c7b172e-f916-11e4-90cd-56ba2fbe2270.png)

Puts the UI on a 48px base grid that is parameterized.

Cleanup of hardcoded CSS.
